### PR TITLE
Fix Tcl 9 compatibility

### DIFF
--- a/msgpack.tcl
+++ b/msgpack.tcl
@@ -1,4 +1,4 @@
-package require Tcl 8.6
+package require Tcl 8.6 9
 package provide msgpack 2.0.0
 
 namespace eval msgpack {}


### PR DESCRIPTION
The code passes tests in Tcl 9.0b1. This PR only expands the required Tcl version range.